### PR TITLE
add syzygy tablebases to selfplay

### DIFF
--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -45,11 +45,6 @@ const OptionId kResignWDLStyleId{
 const OptionId kResignEarliestMoveId{"resign-earliest-move",
                                      "ResignEarliestMove",
                                      "Earliest move that resign is allowed."};
-const OptionId kSyzygyTablebaseId{
-    "syzygy-paths", "SyzygyPath",
-    "List of Syzygy tablebase directories, list entries separated by system "
-    "separator (\";\" for Windows, \":\" for Linux).",
-    's'};
 }  // namespace
 
 void SelfPlayGame::PopulateUciParams(OptionsParser* options) {
@@ -57,7 +52,6 @@ void SelfPlayGame::PopulateUciParams(OptionsParser* options) {
   options->Add<BoolOption>(kResignWDLStyleId) = false;
   options->Add<FloatOption>(kResignPercentageId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kResignEarliestMoveId, 0, 1000) = 0;
-  options->Add<StringOption>(kSyzygyTablebaseId);
 }
 
 SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
@@ -75,20 +69,9 @@ SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
 }
 
 void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
-                        bool enable_resign) {
+                        SyzygyTablebase* syzygy_tb, bool enable_resign) {
   bool blacks_move = false;
 
-  // Take syzygy tablebases from player1 options.
-  std::string tb_paths =
-      options_[0].uci_options->Get<std::string>(kSyzygyTablebaseId.GetId());
-  if (!tb_paths.empty()) {  // && tb_paths != tb_paths_) {
-    syzygy_tb_ = std::make_unique<SyzygyTablebase>();
-    CERR << "Loading Syzygy tablebases from " << tb_paths;
-    if (!syzygy_tb_->init(tb_paths)) {
-      CERR << "Failed to load Syzygy tablebases!";
-      syzygy_tb_ = nullptr;
-    }
-  }
   // Do moves while not end of the game. (And while not abort_)
   while (!abort_) {
     game_result_ = tree_[0]->GetPositionHistory().ComputeGameResult();
@@ -113,8 +96,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
       search_ = std::make_unique<Search>(
           *tree_[idx], options_[idx].network, options_[idx].best_move_callback,
           options_[idx].info_callback, options_[idx].search_limits,
-          *options_[idx].uci_options, options_[idx].cache,
-          syzygy_tb_.get());  // nullptr);
+          *options_[idx].uci_options, options_[idx].cache, syzygy_tb);
     }
 
     // Do search.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -103,6 +103,8 @@ class SelfPlayGame {
 
   // Training data to send.
   std::vector<V4TrainingData> training_data_;
+
+  std::unique_ptr<SyzygyTablebase> syzygy_tb_;
 };
 
 }  // namespace lczero

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -67,10 +67,10 @@ class SelfPlayGame {
 
   // Populate command line options that it uses.
   static void PopulateUciParams(OptionsParser* options);
-
+  
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads, bool training,
-            bool enable_resign = true);
+	  SyzygyTablebase* syzygy_tb, bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();
@@ -83,7 +83,7 @@ class SelfPlayGame {
   // Gets the eval which required the biggest swing up to get the final outcome.
   // Eval is the expected outcome in the range 0<->1.
   float GetWorstEvalForWinnerOrDraw() const;
-
+  
  private:
   // options_[0] is for white player, [1] for black.
   PlayerOptions options_[2];
@@ -104,7 +104,6 @@ class SelfPlayGame {
   // Training data to send.
   std::vector<V4TrainingData> training_data_;
 
-  std::unique_ptr<SyzygyTablebase> syzygy_tb_;
 };
 
 }  // namespace lczero

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -102,6 +102,9 @@ class SelfPlayTournament {
   const size_t kParallelism;
   const bool kTraining;
   const float kResignPlaythrough;
+
+  std::unique_ptr<SyzygyTablebase> syzygy_tb_;
+
 };
 
 }  // namespace lczero


### PR DESCRIPTION
This is a test to see if the chess tablebases can be added for selfplay games.

In general this should save time; on my machine when contributing to leela-training and matches I've seen games prolong between KR vs KR for 200+ moves, just wasting CPU/GPU cycles. 
So the goal here is to use tablebases when those exists; it should just use the tablebases available on your system even if that's only 4 or 5 pieces instead of 6 or 7 piece TB.

Seems to work when starting lco as follows:
lc0 selfplay --visits=800 --syzygy-paths=c:\path_to\tablebases

What probably is needed is that the we enable the go-client to pass on the syzygy-path from commandline to lc0 via commandline, correct?